### PR TITLE
feat: Implement locations list pagination and UI improvements

### DIFF
--- a/app/src/main/java/com/example/prc_pokemon/data/model/Locations.kt
+++ b/app/src/main/java/com/example/prc_pokemon/data/model/Locations.kt
@@ -1,12 +1,15 @@
 package com.example.prc_pokemon.data.model
 
+import com.google.gson.annotations.SerializedName
+
 /** Clase de datos para localizaciones
  * @param locationsInfo : Para paginacion.
  * @param results : Lista de cada localizacion con sus datos.
  * */
 data class Locations(
+    @SerializedName(value = "info")
     val locationsInfo: LocationsInfo,
-    val results: List<SingleLocation>
+    val results: MutableList<SingleLocation>
 )
 
 data class LocationsInfo(

--- a/app/src/main/java/com/example/prc_pokemon/data/network/ApiService.kt
+++ b/app/src/main/java/com/example/prc_pokemon/data/network/ApiService.kt
@@ -9,8 +9,12 @@ import retrofit2.http.Query
 import retrofit2.http.Url
 
 
-//Interfaz retrofit para definir peticiones.
+/**Interfaz retrofit para definir peticiones y/o funciones.*/
 interface ApiService {
+
+    /*
+    * * Main Screen
+    * */
 
     /**Devuelve tres links: Characters, Locations, Epidoses.*/
     @GET("api")
@@ -20,6 +24,10 @@ interface ApiService {
     @GET("api/character")
     suspend fun getCharactersList(): Characters
 
+    /*
+    * * Characters Screen
+    * */
+
     /**Devuelve lista de 20 personajes de la siguiente pagina.*/
     @GET
     suspend fun getCharactersNextPage(@Url url: String): Characters
@@ -28,13 +36,25 @@ interface ApiService {
     @GET
     suspend fun getCharactersPreviousPage(@Url url: String): Characters
 
-    /**Devuelve los personajes ingresados por su nombre.*/
+    /**Devuelve los personajes ingresados por su nombre.
+     * @param nombre Nombre del personaje que se desea encontrar.*/
     @GET(value = "api/character/")
     suspend fun getFilteredCharacter(@Query("name") nombre: String): Characters
+
+    /*
+    * * Locations Screen
+    * */
 
     /**Devuelve lista de todos las localizaciones de la serie.*/
     @GET("api/location")
     suspend fun getLocations(): Locations
+
+    @GET
+    suspend fun getNextLocations(@Url url: String): Locations
+
+    /*
+    * * Episodes Screen
+    * */
 
     /**Devuelve lista de todos los episodios de la serie.*/
     @GET("api/episode")

--- a/app/src/main/java/com/example/prc_pokemon/data/utils/TAGS.kt
+++ b/app/src/main/java/com/example/prc_pokemon/data/utils/TAGS.kt
@@ -3,8 +3,8 @@ package com.example.prc_pokemon.data.utils
 object TAGS {
 
     val TAG_MAINSCREEN_VM = "__MainScreenViewModel__"
-    val TAG_CHARACTERSREEN_VM = "__CharactersScreenList__"
-    val TAG_LOCATIONSSCREEN_VM = "__LocationsScreenList__"
-    val TAG_EPISODESSCREEN_VM = "__EpisodesScreenList__"
+    val TAG_CHARACTERSREEN_VM = "__CharactersScreenVM__"
+    val TAG_LOCATIONSSCREEN_VM = "__LocationsScreenVM__"
+    val TAG_EPISODESSCREEN_VM = "__EpisodesScreenVM__"
 
 }

--- a/app/src/main/java/com/example/prc_pokemon/ui/screens/CharactersListScreen/CharacterListScreenViewModel.kt
+++ b/app/src/main/java/com/example/prc_pokemon/ui/screens/CharactersListScreen/CharacterListScreenViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.launch
 import retrofit2.HttpException
 import java.io.IOException
 
+/**Maneja el estado de la UI de la pantalla de la aplicacion.*/
 sealed interface CharacterScreenUiState {
     data class Success(val charactersList: Characters) : CharacterScreenUiState
     object Loading : CharacterScreenUiState

--- a/app/src/main/java/com/example/prc_pokemon/ui/screens/EpisodesListScreen/EpisodesListScreenViewModel.kt
+++ b/app/src/main/java/com/example/prc_pokemon/ui/screens/EpisodesListScreen/EpisodesListScreenViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import okio.IOException
 import retrofit2.HttpException
 
+/**Maneja el estado de la UI de la pantalla de la aplicacion.*/
 sealed interface EpisodesListScreenUiState {
     data class Success(val episodes: Episodes) : EpisodesListScreenUiState
     object Loading : EpisodesListScreenUiState

--- a/app/src/main/java/com/example/prc_pokemon/ui/screens/LocationsListScreen/LocationsListScreenViewModel.kt
+++ b/app/src/main/java/com/example/prc_pokemon/ui/screens/LocationsListScreen/LocationsListScreenViewModel.kt
@@ -6,24 +6,35 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.prc_pokemon.data.model.Locations
+import com.example.prc_pokemon.data.model.SingleLocation
 import com.example.prc_pokemon.data.network.RetrofitInstance
 import com.example.prc_pokemon.data.utils.TAGS.TAG_LOCATIONSSCREEN_VM
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import okio.IOException
 import retrofit2.HttpException
 
+/**Maneja el estado de la UI de la pantalla de la aplicacion.*/
 sealed interface LocationsListScreenUIState {
-    data class Success(val locations: Locations) : LocationsListScreenUIState
+    object Success : LocationsListScreenUIState
     object Loading : LocationsListScreenUIState
     object Error : LocationsListScreenUIState
 }
 
 class LocationsListScreenViewModel : ViewModel() {
-    var uiState: LocationsListScreenUIState by mutableStateOf(LocationsListScreenUIState.Loading)
 
     private val retrofit = RetrofitInstance.retrofitBuilder
+
+    var uiState: LocationsListScreenUIState by mutableStateOf(LocationsListScreenUIState.Loading)
+
+    private var nextLocationURL = ""
+    private var _isNextLocationURLEmpty = MutableStateFlow(false)
+    val isNextLocationURLEmpty: StateFlow<Boolean> = _isNextLocationURLEmpty
+
+    private val _dinamicList = MutableStateFlow<MutableList<SingleLocation>>(mutableListOf())
+    val dinamicList: StateFlow<MutableList<SingleLocation>> = _dinamicList
 
     init {
         getLocations()
@@ -32,11 +43,41 @@ class LocationsListScreenViewModel : ViewModel() {
     private fun getLocations() {
         viewModelScope.launch {
             try {
-
                 val data = retrofit.getLocations()
+                //Almacena la primera Url.
+                nextLocationURL = data.locationsInfo.next
+                _dinamicList.value = data.results
                 delay(1000)
-                uiState = LocationsListScreenUIState.Success(data)
+                uiState = LocationsListScreenUIState.Success
+            } catch (e: Exception) {
+                Log.e(TAG_LOCATIONSSCREEN_VM, "Error: ${e.message}")
+                uiState = LocationsListScreenUIState.Error
+            } catch (e: IOException) {
+                Log.e(TAG_LOCATIONSSCREEN_VM, "Error: ${e.message}")
+                uiState = LocationsListScreenUIState.Error
+            } catch (e: HttpException) {
+                Log.e(TAG_LOCATIONSSCREEN_VM, "Error: ${e.message}")
+                uiState = LocationsListScreenUIState.Error
+            }
+        }
+    }
 
+    fun getNextLocations() {
+        viewModelScope.launch {
+            try {
+                if (nextLocationURL != null) {
+                    val data = retrofit.getNextLocations(nextLocationURL)
+                    //Almacena la siguiente parte del Url (Hay hasta 7 maximo.)
+                    nextLocationURL = data.locationsInfo.next
+                    //Combina la lista anterior con la siguiente.
+                    _dinamicList.value =
+                        (_dinamicList.value + data.results) as MutableList<SingleLocation>
+                } else {
+                    _isNextLocationURLEmpty.value = true
+                    println("LIMITE")
+                }
+                delay(1000)
+                uiState = LocationsListScreenUIState.Success
             } catch (e: Exception) {
                 Log.e(TAG_LOCATIONSSCREEN_VM, "Error: ${e.message}")
                 uiState = LocationsListScreenUIState.Error


### PR DESCRIPTION
This commit implements pagination for the locations list screen and enhances the UI with loading indicators and end-of-list handling. Key changes include:

- **Locations List Screen:** Implemented infinite scrolling for loading more locations. Added a loading indicator at the bottom of the list while fetching new data and a "Reached the limit" message when all locations are loaded. The UI now dynamically updates as more locations are fetched.
- **Locations List View Model:** Modified to handle pagination. It now tracks the next URL for fetching additional locations and manages a dynamic list of locations. The `getNextLocations` function retrieves the next set of locations and appends them to the existing list. A state flow `isNextLocationURLEmpty` indicates whether all locations have been loaded. The UI state management is updated to reflect these changes.
- **API Service:** Added `getNextLocations` function to `ApiService` for fetching subsequent pages of locations.
- **Data Models:** Modified `Locations` model to use a mutable list for results and added `@SerializedName` for consistency.
- **ViewModel Interface:** Updated the `LocationsListScreenUIState` interface to reflect changes in data handling.
- **TAGS:** Renamed `TAG_LOCATIONSSCREEN_VM` for consistency.
- **Code Comments:** Added and improved code comments to clarify functionality.